### PR TITLE
Add a shallow comparison check to make comparing two tables easier.

### DIFF
--- a/src/tiniest_expect.luau
+++ b/src/tiniest_expect.luau
@@ -70,6 +70,20 @@ function tiniest_expect.expect(
 		return if a == b then tests else fail()
 	end
 
+	function tests.is_shallow_equal(
+		b: any
+	)
+		check(typeof(a) == "table", "expect() value must be a table")
+		check(typeof(b) == "table", "is_shallow_equal() value must be a table")
+		for k, v in a do
+			check(b[k] == v, `Key [{tostring(k)}] is not equivalent. Got {tostring(v)} and {tostring(b[k])}.`)
+		end
+		for k, v in b do
+			check(a[k] == v, `Key [{tostring(k)}] is not equivalent. Got [{tostring(a[k])}] and [{tostring(v)}].`)
+		end
+		return tests
+	end
+
 	function tests.never_is(
 		b: any
 	)


### PR DESCRIPTION
Currently comparing two tables for shallow equivalency can be a pain and causes syntax not inline with other tests. I propose an additional expect test for being able to compare two tables.
```lua
	describe("Append", function()
		test("should append values and maintain order", function()
			local queue = Queue.new()
			queue:Append(11)
			queue:Append(12)
			queue:Append(13)
			expect(queue:ToArray()).is_shallow_equal({11, 12, 13})
		end)
	end)
```