### PR TITLE
Fix expect().never_has_value()

### DIFF
--- a/src/tiniest_expect.luau
+++ b/src/tiniest_expect.luau
@@ -128,7 +128,7 @@ function tiniest_expect.expect(
 		check(typeof(a) == "table", "expect() value must be table")
 		check(b ~= nil, "value cannot be nil")
 		local index = table.find(a, b)
-		return if index ~= nil then tests else fail(`Found at index {index}`)
+		return if index == nil then tests else fail(`Found at index {index}`)
 	end
 
 	function tests.fails()


### PR DESCRIPTION
The expectation for this method is that the expected table should not have the given value. Currently the test looks for if the return value of table.find *is not* nil, however, it should be checking if it *is* nil.