### PR TITLE
Show GitHub actions failing tests in PR interface

### DIFF
--- a/src/tiniest.luau
+++ b/src/tiniest.luau
@@ -104,7 +104,7 @@ function tiniest.configure(
 			local ok, err = catch_errors(inner :: any, root_context)
 			current_context = nil
 			if not ok then
-				error(err.message, 0)
+				error(err, 0)
 			end
 		end
 
@@ -118,7 +118,7 @@ function tiniest.configure(
 			local ok, err = catch_errors(inner :: any, inner_context)
 			current_context = outer_context
 			if not ok then
-				error(err.message, 0)
+				error(err, 0)
 			end
 		end
 	end

--- a/src/tiniest.luau
+++ b/src/tiniest.luau
@@ -17,6 +17,8 @@ type RunContext = {
 
 export type ErrorReport = {
 	type: "tiniest.ErrorReport",
+	line: number,
+	source: string,
 	message: string,
 	trace: string,
 	code: {
@@ -63,8 +65,11 @@ local function catch_errors(func: any, ...)
 		if typeof(message) == "table" and message.type == "tiniest.ErrorReport" then
 			report = message :: ErrorReport
 		else
+			local source, line = debug.info(2, "sl")
 			report = {
 				type = "tiniest.ErrorReport",
+				line = line,
+				source = source,
 				message = tostring(message),
 				trace = debug.traceback(nil, 2)
 			}
@@ -197,8 +202,11 @@ function tiniest.configure(
 						}
 						return fail
 					else
+						local source, line = debug.info(1, "sl")
 						local error: ErrorReport = {
 							type = "tiniest.ErrorReport",
+							line = line,
+							source = source,
 							message = tostring(message),
 							trace = debug.traceback()
 						}

--- a/src/tiniest_expect.luau
+++ b/src/tiniest_expect.luau
@@ -25,13 +25,16 @@ local function fail(
 		quoted[index] = tiniest_quote(param)
 	end
 	local param_list = table.concat(quoted, ",")
+	local source, line = debug.info(4, "sl")
 	error({
 		type = "tiniest.ErrorReport",
+		line = line,
+		source = source,
 		message = "Expectation not met" .. if message == nil then "" else `, because:\n{message}`,
 		trace = debug.traceback(nil, 4),
 		code = {
 			snippet = `expect({tiniest_quote(context.target)}).{context.test}({param_list})`,
-			line = debug.info(4, "l")
+			line = line
 		}
 	}, 0)
 end

--- a/src/tiniest_for_lune.luau
+++ b/src/tiniest_for_lune.luau
@@ -5,11 +5,13 @@ local tiniest_expect = require("./tiniest_expect")
 local tiniest_time = require("./tiniest_time")
 local tiniest_snapshot = require("./tiniest_snapshot")
 local tiniest_pretty = require("./tiniest_pretty")
+local tiniest_github_actions = require("./tiniest_github_actions")
 local tiniest = require("./tiniest")
 
 local require: any = require
 local fs = require("@lune/fs")
 local luau = require("@lune/luau")
+local process = require("@lune/process")
 
 export type Options = {
 	snapshot_path: string?,
@@ -21,7 +23,8 @@ export type Options = {
 		disable_output: nil | {
 			after_run: boolean?
 		}
-	}
+	},
+	github_actions: tiniest_github_actions.Options?
 }
 
 local tiniest_for_lune = {}
@@ -103,8 +106,17 @@ function tiniest_for_lune.configure(
 	})
 	self.format_run = tiniest_pretty.format_run
 
+	local plugins = {tiniest_time :: any, tiniest_snapshot, tiniest_pretty}
+	if process.env.GITHUB_ACTIONS then
+		local tiniest_github_actions = tiniest_github_actions.configure({
+			disable_annotations = options.github_actions and options.github_actions.disable_annotations,
+		})
+
+		table.insert(plugins, tiniest_github_actions)
+	end
+
 	local tiniest = tiniest.configure({
-		plugins = { tiniest_time :: any, tiniest_snapshot, tiniest_pretty }
+		plugins = plugins
 	}) 
 	self.describe = tiniest.describe
 	self.test = tiniest.test

--- a/src/tiniest_github_actions.luau
+++ b/src/tiniest_github_actions.luau
@@ -49,7 +49,7 @@ function tiniest_github_actions.configure(
 			
 			-- need to URL encode new lines for them to show up
 			message = string.gsub(message, "\n", "%%0A")
-			print(`::error file="{file}",line={err.line},title="{title}"::{message}`)
+			print(`::error file={file},line={err.line},title={title}::{message}`)
 		end
 	end
 

--- a/src/tiniest_github_actions.luau
+++ b/src/tiniest_github_actions.luau
@@ -41,8 +41,15 @@ function tiniest_github_actions.configure(
 			local err = result.error
 			local file = extract_filename(err.source)
 			local title = table.concat(test.labels, " > ")
+
+			local message = err.message
+			if err.code then
+				message = `{message}\n  {err.code.snippet}`
+			end
 			
-			print(`::error file="{file}",line={err.line},title="{title}"::{err.message}`)
+			-- need to URL encode new lines for them to show up
+			message = string.gsub(message, "\n", "%%0A")
+			print(`::error file="{file}",line={err.line},title="{title}"::{message}`)
 		end
 	end
 

--- a/src/tiniest_github_actions.luau
+++ b/src/tiniest_github_actions.luau
@@ -1,0 +1,52 @@
+-- From dphfox/tiniest, licenced under BSD
+--!strict
+
+local tiniest = require("./tiniest")
+type Test = tiniest.Test
+
+export type TestRunResult = tiniest.TestRunResult
+export type RunResult = tiniest.RunResult
+
+export type Options = {
+	disable_annotations: boolean?
+}
+
+local tiniest_github_actions = {}
+
+local function extract_filename(source: string)
+	return string.sub(source, 10, #source - 2)
+end
+
+function tiniest_github_actions.configure(
+	options: Options
+)
+	
+	local self = {}
+	self.is_tiniest_plugin = true
+
+	function self.after_run(
+		original_run_result: tiniest.RunResult,
+		_
+	): ()
+        if options.disable_annotations then
+            return
+        end
+
+		local run_result = original_run_result :: RunResult
+		for test, result in run_result.individual do
+            if result.status == "pass" then
+                continue
+            end
+
+			local err = result.error
+			local file = extract_filename(err.source)
+			local title = table.concat(test.labels, " > ")
+			
+			print(`::error file="{file}",line={err.line},title="{title}"::{err.message}`)
+		end
+	end
+
+	return self
+end
+
+return tiniest_github_actions

--- a/src/tiniest_snapshot.luau
+++ b/src/tiniest_snapshot.luau
@@ -79,23 +79,27 @@ function tiniest_snapshot.configure(
 			test_context.num_updated += 1
 			test_context.snapshots[snapshot_index] = fresh_snapshot
 		elseif snapshot_on_disk == nil then
+			local source, line = debug.info(2, "sl")
 			error({
 				type = "tiniest.ErrorReport",
+				source = source,
 				message = "New snapshot() call needs to be saved.\nRun while saving snapshots to save it to disk.",
 				trace = debug.traceback(nil, 2),
 				code = {
 					snippet = `snapshot({fresh_snapshot})`,
-					line = debug.info(2, "l")
+					line = line
 				}
 			}, 0)
 		else
+			local source, line = debug.info(2, "sl")
 			error({
 				type = "tiniest.ErrorReport",
+				source = source,
 				message = "Snapshot does not match",
 				trace = debug.traceback(nil, 2),
 				code = {
 					snippet = `snapshot({fresh_snapshot})\n\n-- snapshot on disk:\nsnapshot({snapshot_on_disk})`,
-					line = debug.info(2, "l")
+					line = line
 				}
 			}, 0)
 		end


### PR DESCRIPTION
## Description
This PR adds support for showing failing tests, ran in GitHub actions, in the GitHub PR user interface.

## Implementation
A new plugin is added that prints out an [error workflow command](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message). The plugin is currently only loaded when using tiniest for Lune while running in a GitHub actions runner (identified using the GITHUB_ACTIONS env variable).

## Additional Details
Error propagation (#5) had to be fixed to make this PR possible, I can split the fix  into a separate PR if requested.

## Example
I've setup an [example PR](https://github.com/1Axen/tiniest/pull/6) in my fork that shows how the annotation looks.
![image](https://github.com/user-attachments/assets/6805553b-a406-4525-8a7f-e89653b9de01)
